### PR TITLE
bugfix/accurics_remediation_6042428101496982 - Auto Generated Pull Request From Accurics

### DIFF
--- a/demo-terraform/aws/simple-ec2-with-s3-access/s3.tf
+++ b/demo-terraform/aws/simple-ec2-with-s3-access/s3.tf
@@ -1,28 +1,33 @@
 
 resource "random_string" "bucket_suffix" {
-    upper = false
-    special = false
-    length = 32
+  upper   = false
+  special = false
+  length  = 32
 }
 
 resource "aws_s3_bucket" "bucket" {
-    bucket = "${replace(local.user_mail,"@","-")}-${random_string.bucket_suffix.result}"
+  bucket = "${replace(local.user_mail, "@", "-")}-${random_string.bucket_suffix.result}"
 
-    tags = local.default_tags
+  tags = local.default_tags
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
 }
 
 resource "aws_s3_bucket_acl" "bucket" {
-    bucket = aws_s3_bucket.bucket.id
-    acl    = "private"
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-    bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.bucket.id
 
-    block_public_acls   = false
-    block_public_policy = false
-    ignore_public_acls = false
-    restrict_public_buckets = false
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 
 # resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {


### PR DESCRIPTION
Perform the steps below to enable MFA delete on an S3 bucket.

Note:
-You cannot enable MFA Delete using the AWS Management Console. You must use the AWS CLI or API.
-You must use your 'root' account to enable MFA Delete on S3 buckets.

**From Command line:**

1. Run the s3api put-bucket-versioning command


aws s3api put-bucket-versioning --profile my-root-profile --bucket Bucket_Name --versioning-configuration Status=Enabled,MFADelete=Enabled --mfa "arn:aws:iam::aws_account_id:mfa/root-account-mfa-device passcode"
